### PR TITLE
Performance improvement on Delta.Push

### DIFF
--- a/delta/delta.go
+++ b/delta/delta.go
@@ -151,8 +151,7 @@ func (d *Delta) Push(newOp Op) *Delta {
 		}
 		if reflect.DeepEqual(newOp.Attributes, lastOp.Attributes) {
 			if newOp.Insert != nil && lastOp.Insert != nil {
-				mergedText := make([]rune, 0, len(lastOp.Insert)+len(newOp.Insert))
-				mergedText = append(lastOp.Insert, newOp.Insert...)
+				mergedText := append(lastOp.Insert, newOp.Insert...)
 				d.Ops[idx-1] = Op{
 					Insert: mergedText,
 				}

--- a/delta/delta_test.go
+++ b/delta/delta_test.go
@@ -924,6 +924,7 @@ func BenchmarkInsert2(t *testing.B) {
 		a.Insert("a", nil)
 	}
 }
+
 func BenchmarkInsert3(t *testing.B) {
 	a := New(nil)
 	for x := 0; x < t.N; x++ {

--- a/delta/op.go
+++ b/delta/op.go
@@ -1,9 +1,5 @@
 package delta
 
-import (
-//"log"
-)
-
 // AttrCompose takes two attributes maps and composes (combine) them
 func AttrCompose(a, b map[string]interface{}, keepNil bool) map[string]interface{} {
 	attributes := make(map[string]interface{})


### PR DESCRIPTION
let the benchmark and pprof speak for themselves:

Original code:

```
$ go test --bench=BenchmarkInsert2 --run=none -benchmem -memprofile=mem0.out
goos: linux
goarch: amd64
BenchmarkInsert2-8   	 1000000	    221429 ns/op	 2004105 B/op	       2 allocs/op
PASS
ok  	_/home/diego/work/fmpwizard/go-quilljs-delta/delta	221.462s
$ go tool pprof --alloc_space mem0.out
File: delta.test
Type: alloc_space
Time: Jun 22, 2019 at 11:55pm (EDT)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 1867.10GB, 100% of 1867.10GB total
Dropped 5 nodes (cum <= 9.34GB)
      flat  flat%   sum%        cum   cum%
 1867.09GB   100%   100%  1867.09GB   100%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Push
    0.01GB 0.00055%   100%  1867.10GB   100%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Insert
         0     0%   100%  1867.10GB   100%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.BenchmarkInsert2
         0     0%   100%  1867.10GB   100%  testing.(*B).launch
         0     0%   100%  1867.10GB   100%  testing.(*B).runN
(pprof) list Push
Total: 1.82TB
ROUTINE ======================== _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Push in /home/diego/work/fmpwizard/go-quilljs-delta/delta/delta.go
    1.82TB     1.82TB (flat, cum)   100% of Total
         .          .    149:			}
         .          .    150:			lastOp = &d.Ops[idx-1]
         .          .    151:		}
         .          .    152:		if reflect.DeepEqual(newOp.Attributes, lastOp.Attributes) {
         .          .    153:			if newOp.Insert != nil && lastOp.Insert != nil {
    1.82TB     1.82TB    154:				mergedText := make([]rune, 0, len(lastOp.Insert)+len(newOp.Insert))
   19.78MB    19.78MB    155:				mergedText = append(lastOp.Insert, newOp.Insert...)
         .          .    156:				d.Ops[idx-1] = Op{
         .          .    157:					Insert: mergedText,
         .          .    158:				}
         .          .    159:				if newOp.Attributes != nil {
         .          .    160:					d.Ops[idx-1].Attributes = newOp.Attributes
(pprof) exit

```


**Big allocation happened when I created the slice mergedText**


```
$ go test --bench=BenchmarkInsert2 --run=none -benchmem -memprofile=mem1.out
goos: linux
goarch: amd64
BenchmarkInsert2-8   	20000000	       118 ns/op	      29 B/op	       1 allocs/op
PASS
ok  	_/home/diego/work/fmpwizard/go-quilljs-delta/delta	2.498s
diego@diego-Precision-5520:~/work/fmpwizard/go-quilljs-delta/delta$ go tool pprof --alloc_space mem1.out
File: delta.test
Type: alloc_space
Time: Jun 23, 2019 at 12:01am (EDT)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top
Showing nodes accounting for 580.80MB, 100% of 580.80MB total
      flat  flat%   sum%        cum   cum%
  420.29MB 72.37% 72.37%   420.29MB 72.37%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Push
  160.50MB 27.63%   100%   580.80MB   100%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Insert
         0     0%   100%   580.80MB   100%  _/home/diego/work/fmpwizard/go-quilljs-delta/delta.BenchmarkInsert2
         0     0%   100%   580.80MB   100%  testing.(*B).launch
         0     0%   100%   580.80MB   100%  testing.(*B).runN
(pprof) list Push
Total: 580.80MB
ROUTINE ======================== _/home/diego/work/fmpwizard/go-quilljs-delta/delta.(*Delta).Push in /home/diego/work/fmpwizard/go-quilljs-delta/delta/delta.go
  420.29MB   420.29MB (flat, cum) 72.37% of Total
         .          .    150:			lastOp = &d.Ops[idx-1]
         .          .    151:		}
         .          .    152:		if reflect.DeepEqual(newOp.Attributes, lastOp.Attributes) {
         .          .    153:			if newOp.Insert != nil && lastOp.Insert != nil {
         .          .    154:				//mergedText := make([]rune, 0, len(lastOp.Insert)+len(newOp.Insert))
  420.29MB   420.29MB    155:				mergedText := append(lastOp.Insert, newOp.Insert...)
         .          .    156:				d.Ops[idx-1] = Op{
         .          .    157:					Insert: mergedText,
         .          .    158:				}
         .          .    159:				if newOp.Attributes != nil {
         .          .    160:					d.Ops[idx-1].Attributes = newOp.Attributes
(pprof) exit

```


**We went from:**

* 221429 ns/op to 118 ns/op
* 2004105 B/op to 29 B/op
* 2 allocs/op to 1 allocs/op

Huge difference, I love Go benchmarks and memory profiles!